### PR TITLE
Component slices

### DIFF
--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -192,7 +192,9 @@ pub fn derive_bundle(input: TokenStream) -> TokenStream {
                     #(#field_from_components)*
                 }
             }
+        }
 
+        impl #impl_generics #ecs_path::bundle::DynamicBundle for #struct_name #ty_generics #where_clause {
             #[allow(unused_variables)]
             #[inline]
             fn get_components(

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -704,7 +704,7 @@ impl Bundles {
         self.bundle_ids.get(&type_id).cloned()
     }
 
-    /// Initializes a new [Bundle]
+    /// Initializes a new [`BundleInfo`] for a statically known type.
     pub fn init_info<'a, T: Bundle>(
         &'a mut self,
         components: &mut Components,
@@ -725,14 +725,20 @@ impl Bundles {
         unsafe { self.bundle_infos.get_unchecked(id.0) }
     }
 
-    /// Initializes a new dynamic [Bundle]
+    /// Initializes a new [`BundleInfo`] for a dynamic [`Bundle`].
     ///
     /// Dynamic bundles are not cached and each call to
-    /// [`Bundles::init_dynamic_info`] will instantiate a new [`BundleInfo`]
+    /// [`Bundles::init_dynamic_info`] will initialize a new [`BundleInfo`]
     /// entry.
     ///
-    /// The user should cache the returned [`BundleInfo`] as is appropriate for
-    /// their needs.
+    /// As each call to this function will initialize a new [`BundleInfo`] the
+    /// user should consider caching the returned [`BundleInfo`] and avoid
+    /// calling this function for the same [`Bundle`] more than once.
+    ///
+    /// # Panics
+    ///
+    /// Panics if any of the provided [`ComponentId`]s do not exist in the
+    /// provided [`Components`].
     pub fn init_dynamic_info<'a>(
         &'a mut self,
         components: &mut Components,
@@ -752,7 +758,7 @@ impl Bundles {
         let bundle_info = unsafe { initialize_bundle("<dynamic bundle>", component_ids, id) };
         bundle_infos.push(bundle_info);
 
-        // SAFETY: index either exists, or was initialized
+        // SAFETY: index was initialized just above
         unsafe { bundle_infos.get_unchecked(id.0) }
     }
 }

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -771,7 +771,7 @@ impl Bundles {
         &mut self,
         components: &mut Components,
         component_id: ComponentId,
-    ) -> (&BundleInfo, &StorageType) {
+    ) -> (&BundleInfo, StorageType) {
         let bundle_infos = &mut self.bundle_infos;
         let (bundle_id, storage_types) = self
             .dynamic_component_bundle_ids
@@ -786,7 +786,7 @@ impl Bundles {
         // SAFETY: index either exists, or was initialized
         let bundle_info = unsafe { bundle_infos.get_unchecked(bundle_id.0) };
 
-        (bundle_info, storage_types)
+        (bundle_info, *storage_types)
     }
 }
 

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -741,7 +741,7 @@ impl Bundles {
         for &id in &component_ids {
             components.get_info(id).unwrap_or_else(|| {
                 panic!(
-                    "insert_bundle_by_ids called with component id {id:?} which doesn't exist in this world"
+                    "init_dynamic_info called with component id {id:?} which doesn't exist in this world"
                 )
             });
         }

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -1138,7 +1138,32 @@ mod tests {
     }
 
     #[test]
-    fn entity_mut_cached_bundle_id() {}
+    fn entity_mut_cached_bundle_id() {
+        let mut world = World::new();
+        let test_component_id = world.init_component::<TestComponent>();
+        let test_component_2_id = world.init_component::<TestComponent2>();
+
+        assert_eq!(
+            world.init_bundle::<TestComponent>().id(),
+            world.init_bundle::<TestComponent>().id()
+        );
+
+        // Test single component case
+        assert_eq!(
+            world.init_dynamic_bundle(vec![test_component_id]).id(),
+            world.init_dynamic_bundle(vec![test_component_id]).id()
+        );
+
+        // Test dynamic component case
+        assert_eq!(
+            world
+                .init_dynamic_bundle(vec![test_component_id, test_component_2_id])
+                .id(),
+            world
+                .init_dynamic_bundle(vec![test_component_id, test_component_2_id])
+                .id()
+        );
+    }
 
     #[test]
     fn entity_mut_insert_by_id() {

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -799,11 +799,10 @@ fn contains_component_with_id(
 /// Inserts a dynamic [`Bundle`] into the entity.
 unsafe fn insert_dynamic_bundle<
     'a,
-    'b,
     I: Iterator<Item = OwningPtr<'a>>,
     S: Iterator<Item = StorageType>,
 >(
-    mut bundle_inserter: BundleInserter<'_, 'b>,
+    mut bundle_inserter: BundleInserter<'_, '_>,
     entity: Entity,
     location: EntityLocation,
     components: I,

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -379,8 +379,7 @@ impl<'w> EntityMut<'w> {
     ///
     /// This will overwrite any previous value(s) of the same component type.
     ///
-    /// You should prefer to use the typed API [`EntityMut::insert`] where possible and only
-    /// use this in cases where there is no static type corresponding to the [`BundleId`].
+    /// You should prefer to use the typed API [`EntityMut::insert`] where possible.
     ///
     /// # Safety
     ///
@@ -421,11 +420,8 @@ impl<'w> EntityMut<'w> {
     ///
     /// This will overwrite any previous value(s) of the same component type.
     ///
-    /// You should prefer to use the typed API [`EntityMut::insert`] where possible and only
-    /// use this in cases where there is no static type corresponding to the [`BundleId`].
+    /// You should prefer to use the typed API [`EntityMut::insert`] where possible.
     /// If your [`Bundle`] only has one component, use the cached API [`EntityMut::insert_by_id`].
-    ///
-    /// To obtain a [`BundleId`] you can call [`World::init_bundle`] or [`World::init_dynamic_bundle`].
     ///
     /// # Safety
     /// - Each [`ComponentId`] must be from the same world as [`EntityMut`]

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -1107,7 +1107,6 @@ mod tests {
         let test_component_id = world.init_component::<TestComponent>();
 
         let mut entity = world.spawn_empty();
-
         OwningPtr::make(TestComponent(42), |ptr| {
             // SAFETY: `ptr` matches the component id
             unsafe { entity.insert_by_id(test_component_id, ptr) };

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -386,7 +386,7 @@ impl<'w> EntityMut<'w> {
         value: OwningPtr<'_>,
     ) -> &mut Self {
         // SAFETY: the caller promisees that `value` is valid for the `component_id`
-        self.insert_bundle_by_ids(vec![component_id], vec![value])
+        self.insert_bundle_by_ids(vec![component_id], std::iter::once(value))
     }
 
     /// Inserts a bundle of components into the entity. Will replace the values if they already existed.
@@ -396,10 +396,10 @@ impl<'w> EntityMut<'w> {
     ///
     /// # Safety
     /// - each value of `components` must be valid for the [`ComponentId`] at the matching position in `component_ids` in this world
-    pub unsafe fn insert_bundle_by_ids(
+    pub unsafe fn insert_bundle_by_ids<'a, I: IntoIterator<Item = OwningPtr<'a>>>(
         &mut self,
         mut component_ids: Vec<ComponentId>,
-        components: Vec<OwningPtr<'_>>,
+        components: I,
     ) -> &mut Self {
         component_ids.sort();
 
@@ -411,16 +411,18 @@ impl<'w> EntityMut<'w> {
             });
         }
 
-        struct DynamicInsertBundle<'a> {
-            components: Vec<OwningPtr<'a>>,
+        struct DynamicInsertBundle<'a, I: Iterator<Item = OwningPtr<'a>>> {
+            components: I,
         }
-        impl DynamicBundle for DynamicInsertBundle<'_> {
+        impl<'a, I: Iterator<Item = OwningPtr<'a>>> DynamicBundle for DynamicInsertBundle<'a, I> {
             fn get_components(self, func: &mut impl FnMut(OwningPtr<'_>)) {
-                self.components.into_iter().for_each(func);
+                self.components.for_each(func);
             }
         }
 
-        let bundle = DynamicInsertBundle { components };
+        let bundle = DynamicInsertBundle {
+            components: components.into_iter(),
+        };
 
         let change_tick = self.world.change_tick();
         // SAFETY: component_ids are all valid, because they are checked in this function

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -395,13 +395,14 @@ impl<'w> EntityMut<'w> {
     /// use this in cases where there are no Rust types corresponding to the [`ComponentId`]s.
     ///
     /// # Safety
-    /// - the `component_ids` list must be sorted
     /// - each value of `components` must be valid for the [`ComponentId`] at the matching position in `component_ids` in this world
     pub unsafe fn insert_bundle_by_ids(
         &mut self,
-        component_ids: Vec<ComponentId>,
+        mut component_ids: Vec<ComponentId>,
         components: Vec<OwningPtr<'_>>,
     ) -> &mut Self {
+        component_ids.sort();
+
         for &id in &component_ids {
             self.world.components().get_info(id).unwrap_or_else(|| {
                 panic!(

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -797,6 +797,12 @@ fn contains_component_with_id(
 }
 
 /// Inserts a dynamic [`Bundle`] into the entity.
+///
+/// # Safety
+///
+/// - [`OwningPtr`] and [`StorageType`] iterators must correspond to the
+/// [`BundleInfo`] used to construct [`BundleInserter`]
+/// - [`Entity`] must correspond to [`EntityLocation`]
 unsafe fn insert_dynamic_bundle<
     'a,
     I: Iterator<Item = OwningPtr<'a>>,
@@ -824,7 +830,7 @@ unsafe fn insert_dynamic_bundle<
         components: storage_types.zip(components),
     };
 
-    // SAFETY: location matches current entity. The `bundle` matches `bundle_info` components as promised by the caller.
+    // SAFETY: location matches current entity.
     bundle_inserter.insert(entity, location, bundle)
 }
 

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -439,14 +439,6 @@ impl<'w> EntityMut<'w> {
         self
     }
 
-    #[deprecated(
-        since = "0.9.0",
-        note = "Use `remove` instead, which now accepts bundles, components, and tuples of bundles and components."
-    )]
-    pub fn remove_bundle<T: Bundle>(&mut self) -> Option<T> {
-        self.remove::<T>()
-    }
-
     // TODO: move to BundleInfo
     /// Removes a [`Bundle`] of components from the entity and returns the bundle.
     ///

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -410,7 +410,7 @@ impl<'w> EntityMut<'w> {
             self.entity,
             self.location,
             Some(component).into_iter(),
-            Some(*storage_type).into_iter(),
+            Some(storage_type).into_iter(),
         );
 
         self
@@ -422,6 +422,8 @@ impl<'w> EntityMut<'w> {
     ///
     /// You should prefer to use the typed API [`EntityMut::insert`] where possible.
     /// If your [`Bundle`] only has one component, use the cached API [`EntityMut::insert_by_id`].
+    ///
+    /// If possible, pass a sorted slice of `ComponentId` to maximize caching potential.
     ///
     /// # Safety
     /// - Each [`ComponentId`] must be from the same world as [`EntityMut`]
@@ -451,7 +453,7 @@ impl<'w> EntityMut<'w> {
             self.entity,
             self.location,
             iter_components,
-            storage_types.iter().map(Clone::clone),
+            storage_types.iter().cloned(),
         );
 
         self

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -391,7 +391,11 @@ impl<'w> EntityMut<'w> {
         component_id: ComponentId,
         component: OwningPtr<'a>,
     ) -> &mut Self {
-        let (storage_type, id) = self.world.bundles.get_component(component_id).unwrap();
+        let (storage_type, id) = self.world.bundles.get_component(component_id).unwrap_or_else(|| {
+            panic!(
+                "`insert_by_id` called with component id {component_id:?} which wasn't registered as a bundle, register it using `World::init_dynamic_bundle`"
+            )
+        });
         self.insert_bundle_by_id_unchecked(id, Some((storage_type, component)))
     }
 
@@ -415,7 +419,11 @@ impl<'w> EntityMut<'w> {
         components: I,
     ) -> &mut Self {
         let world_components = &self.world.components;
-        let bundle_info = self.world.bundles.get(bundle_id).unwrap();
+        let bundle_info = self.world.bundles.get(bundle_id).unwrap_or_else(|| {
+            panic!(
+                "`insert_bundle_by_id` called with bundle id {bundle_id:?} which wasn't registered, register it using `World::init_dynamic_bundle`"
+            )
+        });
 
         let iter = components
             .into_iter()
@@ -472,7 +480,11 @@ impl<'w> EntityMut<'w> {
 
         let change_tick = self.world.change_tick();
 
-        let bundle_info = self.world.bundles.get(bundle_id).unwrap();
+        let bundle_info = self.world.bundles.get(bundle_id).unwrap_or_else(|| {
+            panic!(
+                "`insert_bundle_by_id_unchecked` called with bundle id {bundle_id:?} which wasn't registered, register it using `World::init_dynamic_bundle`"
+            )
+        });
         let mut bundle_inserter = bundle_info.get_bundle_inserter(
             &mut self.world.entities,
             &mut self.world.archetypes,

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -1,10 +1,8 @@
 use crate::{
     archetype::{Archetype, ArchetypeId, Archetypes},
-    bundle::{Bundle, BundleInfo},
-    change_detection::{MutUntyped, TicksMut},
-    component::{
-        Component, ComponentId, ComponentStorage, ComponentTicks, Components, StorageType,
-    },
+    bundle::{Bundle, BundleInfo, DynamicBundle},
+    change_detection::{MutUntyped, Ticks},
+    component::{Component, ComponentId, ComponentTicks, Components, StorageType},
     entity::{Entities, Entity, EntityLocation},
     storage::{SparseSet, Storages},
     world::{Mut, World},
@@ -373,6 +371,82 @@ impl<'w> EntityMut<'w> {
         }
 
         self
+    }
+
+    /// Inserts a component with the given `value`. Will replace the value if it already existed.
+    ///
+    /// **You should prefer to use the typed API [`EntityMut::insert`] where possible and only
+    /// use this in cases where there isn't a Rust type corresponding to the [`ComponentId`].
+    ///
+    /// # Safety
+    /// The value referenced by `value` must be valid for the given [`ComponentId`] of this world
+    pub unsafe fn insert_by_id(
+        &mut self,
+        component_id: ComponentId,
+        value: OwningPtr<'_>,
+    ) -> &mut Self {
+        // SAFETY: the caller promisees that `value` is valid for the `component_id`
+        self.insert_bundle_by_ids(vec![component_id], vec![value])
+    }
+
+    /// Inserts a bundle of components into the entity. Will replace the values if they already existed.
+    ///
+    /// **You should prefer to use the typed API [`EntityMut::insert_bundle`] where possible and only
+    /// use this in cases where there are no Rust types corresponding to the [`ComponentId`]s.
+    ///
+    /// # Safety
+    /// - the `component_ids` list must be sorted
+    /// - each value of `components` must be valid for the [`ComponentId`] at the matching position in `component_ids` in this world
+    pub unsafe fn insert_bundle_by_ids(
+        &mut self,
+        component_ids: Vec<ComponentId>,
+        components: Vec<OwningPtr<'_>>,
+    ) -> &mut Self {
+        for &id in &component_ids {
+            self.world.components().get_info(id).unwrap_or_else(|| {
+                panic!(
+                    "insert_bundle_by_ids called with component id {id:?} which doesn't exist in this world"
+                )
+            });
+        }
+
+        struct DynamicInsertBundle<'a> {
+            components: Vec<OwningPtr<'a>>,
+        }
+        impl DynamicBundle for DynamicInsertBundle<'_> {
+            fn get_components(self, func: &mut impl FnMut(OwningPtr<'_>)) {
+                self.components.into_iter().for_each(func);
+            }
+        }
+
+        let bundle = DynamicInsertBundle { components };
+
+        let change_tick = self.world.change_tick();
+        // SAFETY: component_ids are all valid, because they are checked in this function
+        let bundle_info = self
+            .world
+            .bundles
+            .init_info_dynamic(&mut self.world.components, component_ids);
+        let mut bundle_inserter = bundle_info.get_bundle_inserter(
+            &mut self.world.entities,
+            &mut self.world.archetypes,
+            &mut self.world.components,
+            &mut self.world.storages,
+            self.location.archetype_id,
+            change_tick,
+        );
+        // SAFETY: location matches current entity. The `bundle` matches `bundle_info` components as promised by the caller.
+        self.location = bundle_inserter.insert(self.entity, self.location.index, bundle);
+
+        self
+    }
+
+    #[deprecated(
+        since = "0.9.0",
+        note = "Use `remove` instead, which now accepts bundles, components, and tuples of bundles and components."
+    )]
+    pub fn remove_bundle<T: Bundle>(&mut self) -> Option<T> {
+        self.remove::<T>()
     }
 
     // TODO: move to BundleInfo
@@ -927,6 +1001,8 @@ pub(crate) unsafe fn take_component<'a>(
 
 #[cfg(test)]
 mod tests {
+    use bevy_ptr::OwningPtr;
+
     use crate as bevy_ecs;
     use crate::component::ComponentId;
     use crate::prelude::*; // for the `#[derive(Component)]`
@@ -954,6 +1030,9 @@ mod tests {
 
     #[derive(Component)]
     struct TestComponent(u32);
+
+    #[derive(Component)]
+    struct TestComponent2(u32);
 
     #[test]
     fn entity_ref_get_by_id() {
@@ -1017,5 +1096,43 @@ mod tests {
         let mut entity = world.spawn_empty();
         assert!(entity.get_by_id(invalid_component_id).is_none());
         assert!(entity.get_mut_by_id(invalid_component_id).is_none());
+    }
+
+    #[test]
+    fn entity_mut_insert_by_id() {
+        let mut world = World::new();
+        let test_component_id = world.init_component::<TestComponent>();
+
+        let mut entity = world.spawn_empty();
+
+        OwningPtr::make(TestComponent(42), |ptr| {
+            // SAFETY: `ptr` matches the component id
+            unsafe { entity.insert_by_id(test_component_id, ptr) };
+        });
+
+        assert_eq!(entity.get::<TestComponent>().unwrap().0, 42);
+    }
+
+    #[test]
+    fn entity_mut_insert_bundle_by_ids() {
+        let mut world = World::new();
+        let test_component_id = world.init_component::<TestComponent>();
+        let test_component_2_id = world.init_component::<TestComponent2>();
+
+        let mut entity = world.spawn_empty();
+
+        let component_ids = vec![test_component_id, test_component_2_id];
+        let test_component_value = TestComponent(42);
+        let test_component_2_value = TestComponent2(84);
+
+        OwningPtr::make(test_component_value, |ptr1| {
+            OwningPtr::make(test_component_2_value, |ptr2| {
+                // SAFETY: `ptr1` and `ptr2` match the component ids
+                unsafe { entity.insert_bundle_by_ids(component_ids, vec![ptr1, ptr2]) };
+            });
+        });
+
+        assert_eq!(entity.get::<TestComponent>().unwrap().0, 42);
+        assert_eq!(entity.get::<TestComponent2>().unwrap().0, 84);
     }
 }

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -430,7 +430,7 @@ impl<'w> EntityMut<'w> {
     /// - Each [`OwningPtr`] must be a valid reference to the type represented by [`ComponentId`]
     pub unsafe fn insert_bundle_by_id<'a, I: Iterator<Item = OwningPtr<'a>>>(
         &mut self,
-        component_ids: &Vec<ComponentId>,
+        component_ids: &[ComponentId],
         iter_components: I,
     ) -> &mut Self {
         let change_tick = self.world.change_tick();
@@ -1167,7 +1167,7 @@ mod tests {
         let mut entity = world.spawn_empty();
         OwningPtr::make(TestComponent(84), |ptr| {
             // SAFETY: `ptr` matches the component id
-            unsafe { entity.insert_bundle_by_id(&vec![test_component_id], vec![ptr].into_iter()) };
+            unsafe { entity.insert_bundle_by_id(&[test_component_id], [ptr].into_iter()) };
         });
 
         let components: Vec<_> = world.query::<&TestComponent>().iter(&world).collect();
@@ -1181,7 +1181,7 @@ mod tests {
         let test_component_id = world.init_component::<TestComponent>();
         let test_component_2_id = world.init_component::<TestComponent2>();
 
-        let component_ids = vec![test_component_id, test_component_2_id];
+        let component_ids = [test_component_id, test_component_2_id];
         let test_component_value = TestComponent(42);
         let test_component_2_value = TestComponent2(84);
 
@@ -1189,7 +1189,7 @@ mod tests {
         OwningPtr::make(test_component_value, |ptr1| {
             OwningPtr::make(test_component_2_value, |ptr2| {
                 // SAFETY: `ptr1` and `ptr2` match the component ids
-                unsafe { entity.insert_bundle_by_id(&component_ids, vec![ptr1, ptr2].into_iter()) };
+                unsafe { entity.insert_bundle_by_id(&component_ids, [ptr1, ptr2].into_iter()) };
             });
         });
 

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -9,7 +9,7 @@ pub use world_cell::*;
 
 use crate::{
     archetype::{ArchetypeComponentId, ArchetypeId, ArchetypeRow, Archetypes},
-    bundle::{Bundle, BundleInserter, BundleSpawner, Bundles},
+    bundle::{Bundle, BundleInfo, BundleInserter, BundleSpawner, Bundles},
     change_detection::{MutUntyped, TicksMut},
     component::{
         Component, ComponentDescriptor, ComponentId, ComponentInfo, ComponentTicks, Components,
@@ -170,6 +170,17 @@ impl World {
     ) -> ComponentId {
         self.components
             .init_component_with_descriptor(&mut self.storages, descriptor)
+    }
+
+    pub fn init_bundle<'a, T: Bundle>(&'a mut self) -> &'a BundleInfo {
+        let components = &mut self.components;
+        let storages = &mut self.storages;
+        self.bundles.init_info::<T>(components, storages)
+    }
+
+    pub fn init_dynamic_bundle(&mut self, component_ids: Vec<ComponentId>) -> &BundleInfo {
+        let components = &mut self.components;
+        self.bundles.init_dynamic_info(components, component_ids)
     }
 
     /// Returns the [`ComponentId`] of the given [`Component`] type `T`.

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -172,12 +172,32 @@ impl World {
             .init_component_with_descriptor(&mut self.storages, descriptor)
     }
 
+    /// Initializes a new [`BundleInfo`] for a statically known type.
+    ///
+    /// The returned [`BundleInfo`] can be used to dynamically insert components into entities
+    /// using [`EntityMut::insert_by_id`] and [`EntityMut::insert_bundle_by_id`].
     pub fn init_bundle<T: Bundle>(&mut self) -> &BundleInfo {
         let components = &mut self.components;
         let storages = &mut self.storages;
         self.bundles.init_info::<T>(components, storages)
     }
 
+    /// Initializes a new [`BundleInfo`] for a dynamic type.
+    ///
+    /// The returned [`BundleInfo`] can be used to dynamically insert components into entities
+    /// using [`EntityMut::insert_by_id`] and [`EntityMut::insert_bundle_by_id`].
+    ///
+    /// Dynamic bundles are not cached and each call to [`init_dynamic_bundle`]
+    /// will initialize a new [`BundleInfo`] entry.
+    ///
+    /// As each call to this function will initialize a new [`BundleInfo`] the
+    /// user should consider caching the returned [`BundleInfo`] and avoid
+    /// calling this function for the same [`Bundle`] more than once.
+    ///
+    /// # Panics
+    ///
+    /// Panics if any of the provided [`ComponentId`]s do not exist in the
+    /// provided [`World`].
     pub fn init_dynamic_bundle(&mut self, component_ids: Vec<ComponentId>) -> &BundleInfo {
         let components = &mut self.components;
         self.bundles.init_dynamic_info(components, component_ids)

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -175,7 +175,7 @@ impl World {
     /// Initializes a new [`BundleInfo`] for a statically known type.
     ///
     /// The returned [`BundleInfo`] can be used to dynamically insert components into entities
-    /// using [`EntityMut::insert_by_id`] and [`EntityMut::insert_by_id`].
+    /// using [`EntityMut::insert_by_id`] and [`EntityMut::insert_bundle_by_id`].
     pub fn init_bundle<T: Bundle>(&mut self) -> &BundleInfo {
         let components = &mut self.components;
         let storages = &mut self.storages;
@@ -185,14 +185,7 @@ impl World {
     /// Initializes a new [`BundleInfo`] for a dynamic type.
     ///
     /// The returned [`BundleInfo`] can be used to dynamically insert components into entities
-    /// using [`EntityMut::insert_by_id`] and [`EntityMut::insert_by_id`].
-    ///
-    /// Dynamic bundles are not cached and each call to this function will
-    /// initialize a new [`BundleInfo`] entry.
-    ///
-    /// As each call to this function will initialize a new [`BundleInfo`] the
-    /// user should consider caching the returned [`BundleInfo`] and avoid
-    /// calling this function for the same [`Bundle`] more than once.
+    /// using [`EntityMut::insert_by_id`] and [`EntityMut::insert_bundle_by_id`].
     ///
     /// # Panics
     ///

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -9,7 +9,7 @@ pub use world_cell::*;
 
 use crate::{
     archetype::{ArchetypeComponentId, ArchetypeId, ArchetypeRow, Archetypes},
-    bundle::{Bundle, BundleInfo, BundleInserter, BundleSpawner, Bundles},
+    bundle::{Bundle, BundleInserter, BundleSpawner, Bundles},
     change_detection::{MutUntyped, TicksMut},
     component::{
         Component, ComponentDescriptor, ComponentId, ComponentInfo, ComponentTicks, Components,
@@ -170,30 +170,6 @@ impl World {
     ) -> ComponentId {
         self.components
             .init_component_with_descriptor(&mut self.storages, descriptor)
-    }
-
-    /// Initializes a new [`BundleInfo`] for a statically known type.
-    ///
-    /// The returned [`BundleInfo`] can be used to dynamically insert components into entities
-    /// using [`EntityMut::insert_by_id`] and [`EntityMut::insert_bundle_by_id`].
-    pub fn init_bundle<T: Bundle>(&mut self) -> &BundleInfo {
-        let components = &mut self.components;
-        let storages = &mut self.storages;
-        self.bundles.init_info::<T>(components, storages)
-    }
-
-    /// Initializes a new [`BundleInfo`] for a dynamic type.
-    ///
-    /// The returned [`BundleInfo`] can be used to dynamically insert components into entities
-    /// using [`EntityMut::insert_by_id`] and [`EntityMut::insert_bundle_by_id`].
-    ///
-    /// # Panics
-    ///
-    /// Panics if any of the provided [`ComponentId`]s do not exist in the
-    /// provided [`World`].
-    pub fn init_dynamic_bundle(&mut self, component_ids: Vec<ComponentId>) -> &BundleInfo {
-        let components = &mut self.components;
-        self.bundles.init_dynamic_info(components, component_ids)
     }
 
     /// Returns the [`ComponentId`] of the given [`Component`] type `T`.

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -175,7 +175,7 @@ impl World {
     /// Initializes a new [`BundleInfo`] for a statically known type.
     ///
     /// The returned [`BundleInfo`] can be used to dynamically insert components into entities
-    /// using [`EntityMut::insert_by_id`] and [`EntityMut::insert_bundle_by_id`].
+    /// using [`EntityMut::insert_by_id`] and [`EntityMut::insert_by_id`].
     pub fn init_bundle<T: Bundle>(&mut self) -> &BundleInfo {
         let components = &mut self.components;
         let storages = &mut self.storages;
@@ -185,10 +185,10 @@ impl World {
     /// Initializes a new [`BundleInfo`] for a dynamic type.
     ///
     /// The returned [`BundleInfo`] can be used to dynamically insert components into entities
-    /// using [`EntityMut::insert_by_id`] and [`EntityMut::insert_bundle_by_id`].
+    /// using [`EntityMut::insert_by_id`] and [`EntityMut::insert_by_id`].
     ///
-    /// Dynamic bundles are not cached and each call to [`init_dynamic_bundle`]
-    /// will initialize a new [`BundleInfo`] entry.
+    /// Dynamic bundles are not cached and each call to this function will
+    /// initialize a new [`BundleInfo`] entry.
     ///
     /// As each call to this function will initialize a new [`BundleInfo`] the
     /// user should consider caching the returned [`BundleInfo`] and avoid

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -172,7 +172,7 @@ impl World {
             .init_component_with_descriptor(&mut self.storages, descriptor)
     }
 
-    pub fn init_bundle<'a, T: Bundle>(&'a mut self) -> &'a BundleInfo {
+    pub fn init_bundle<T: Bundle>(&mut self) -> &BundleInfo {
         let components = &mut self.components;
         let storages = &mut self.storages;
         self.bundles.init_info::<T>(components, storages)


### PR DESCRIPTION
Manually hash component slices to compare with `Vec` keys.

It is actually possible to avoid storing the second component ID vector by setting the key to `BundleId`. Then `from_hash` can index directly into `bundle_infos` and compare to the component vector there. But this is quite hacky so I left it out.

 `dynamic_bundle_ids: HashMap<BundleId, Vec<StorageType>, fxhash::FxBuildHasher>`